### PR TITLE
Fix invalid image metadata in Landing page

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     type: 'website',
     images: [
       {
-        url: `${process.env.NEXT_PUBLIC_BASE_URL}/screenshots/landing.png`,
+        url: 'https://www.cashush.com/screenshots/landing.png',
       },
     ],
   },
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title,
     description,
-    images: [`${process.env.NEXT_PUBLIC_BASE_URL}/screenshots/landing.png`],
+    images: ['https://www.cashush.com/screenshots/landing.png'],
   },
 };
 


### PR DESCRIPTION
## Description

The `og:image` meta tag is having an invalid value, i.e. `https://www.cashush.com/undefined/screenshots/landing.png`

## Solution

Fix the issue by putting a fixed url that pointing to the landing's screenshot